### PR TITLE
Guide説明をREADMEに同期

### DIFF
--- a/components/Guide.tsx
+++ b/components/Guide.tsx
@@ -31,6 +31,9 @@ export const Guide: React.FC = () => {
                   本来の「オーナーシップ」どおりの意味で、「リーダーシップ」とは別の概念です。<br />
                   このモデルにおけるリーダーシップは関係性軸の融合と帰属軸のオーナーシップが両方とも高く融合コストを他者に置いている状態です。
                 </p>
+                <p className="text-body text-gray-paragraph">
+                  ownership側は、関心の向き（内在構造／品質）、関与の深さと疲労、初期創発フェーズの手応え、思考や関与痕跡への満足という内側で完結する価値生成プロセスを一貫してカバーしています。
+                </p>
               </header>
               <div className="pl-4 border-l-2 border-gray-border">
                 <p className="text-label text-gray-caption mb-2">端点に近づくと顕在化する傾向：</p>
@@ -42,7 +45,12 @@ export const Guide: React.FC = () => {
                       <li>端点へ極端に近いと、こだわりすぎて効率化を犠牲にする場合があります。</li>
                     </ul>
                   </li>
-                  <li>0→1の価値創出と親和性が高い特性です。一方で、自発的要素のないタスクへモチベーションを見い出しにくい傾向があります。</li>
+                  <li>0→1の価値創出と親和性が高い特性です。一方で、自発的要素のないタスクへモチベーションを見い出しにくい傾向があります。
+                    <ul className="list-disc pl-5 mt-1 flex flex-col gap-1">
+                      <li>内在構造や完成度そのものに価値を感じ、関与が深くなる志向。</li>
+                      <li>成果よりも関与や思考の痕跡が残ることに価値を感じる内在的満足の傾向。</li>
+                    </ul>
+                  </li>
                 </ul>
               </div>
             </section>
@@ -51,6 +59,9 @@ export const Guide: React.FC = () => {
                 <h4 className="text-h4-mobile lg:text-h4 text-dark">コンセンサス</h4>
                 <p className="text-body text-gray-paragraph">
                   コンセンサス志向は、総和をつくり責任を場や合意へ移譲する選好です。
+                </p>
+                <p className="text-body text-gray-paragraph">
+                  consensus側は、流通・配置・根回し、公開・展開・運用フェーズ、反応による完了感、役割としての遂行、承認による納得補強といった外部との接続点で価値が立ち上がるプロセスを段階的に分解しています。
                 </p>
               </header>
               <div className="pl-4 border-l-2 border-gray-border">
@@ -64,6 +75,8 @@ export const Guide: React.FC = () => {
                     </ul>
                   </li>
                   <li>0→1の価値創出は苦手ですが、補助的関与にもモチベーションの波を持ち込まず対処できる傾向があります。</li>
+                  <li>内容そのものよりも流通・配置・合意形成によって価値が変わる点への関心。</li>
+                  <li>形を出すことより、外部からの反応によって完了感が成立する価値観。</li>
                 </ul>
               </div>
             </section>
@@ -88,6 +101,9 @@ export const Guide: React.FC = () => {
                 <p className="text-label text-gray-caption">
                   心理学本来の「自立」とは厳密に一致していません。融合の対角へダイバーシティを配置したときの誤認バイアスを軽減する目的で「自立」を採用しています。
                 </p>
+                <p className="text-body text-gray-paragraph">
+                  境界は「近い／遠い」「自立／孤立」ではなく、評価・解釈・関係・集団構造・信頼の揺らぎという異なる侵入経路ごとに検知されます。
+                </p>
               </header>
               <div className="pl-4 border-l-2 border-gray-border">
                 <p className="text-label text-gray-caption mb-2">端点に近づくと顕在化する傾向：</p>
@@ -99,6 +115,10 @@ export const Guide: React.FC = () => {
                     </ul>
                   </li>
                   <li>同質化と社交性は異義です。したがって単独選好と自立志向も異義です。</li>
+                  <li>話題性や権威と評価軸を混線させることへの直感的な境界検知。</li>
+                  <li>正義や立場を固定せず、複数の解釈を並列で保持できる境界特性。</li>
+                  <li>自分の評価と他者の関心を分離して扱える境界の安定性。</li>
+                  <li>能力評価を一時的な成果変動と切り分けて捉えられる境界感覚。</li>
                 </ul>
               </div>
             </section>
@@ -118,6 +138,11 @@ export const Guide: React.FC = () => {
                       <li>収束のための変化は、自分で対応する場合と外部へ求める場合の両方があります。</li>
                     </ul>
                   </li>
+                  <li>関係性を軸に進行を安定させる融合的な進め方への親和性。</li>
+                  <li>他者の評価フレームに即座に同調し、自身の判断と混線させやすい傾向。</li>
+                  <li>他者の感想を自分の評価として内面化・表明する境界の曖昧さ。</li>
+                  <li>代表への委譲や一体感によって安心を得る融合志向。</li>
+                  <li>決定結果よりも関係の残余や同質性を気にかける融合的感受性。</li>
                 </ul>
               </div>
             </section>


### PR DESCRIPTION
## Summary
- Guideの帰属志向/関係性志向の説明文をREADMEと同期
- 端点に近づくと顕在化する傾向の項目をREADMEに合わせて追記

## Test plan
ユーザーがlocalhostで表示確認済み

## Issues
- Fixes #38