### PR TITLE
Hotfix: 「この結果のURLをコピー」でfocusが反映されない

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "current-gravity",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/_parts/GroupEditor/useGroupEditor.ts
+++ b/src/app/_parts/GroupEditor/useGroupEditor.ts
@@ -18,8 +18,11 @@ function buildHomeShareUrlFromGroup(group: PersonalPlotGroup): string {
     params.set('name', group.name)
   }
   group.personalPlotList.forEach(p => {
-    const pData = [p.displayName, p.ownership, p.consensus, p.diversity, p.identityFusion].join(',')
-    params.append('p', pData)
+    const parts: (string | number)[] = [p.displayName, p.ownership, p.consensus, p.diversity, p.identityFusion]
+    if (p.focus) {
+      parts.push('f')
+    }
+    params.append('p', parts.join(','))
   })
   const qs = params.toString()
   const origin = typeof window !== 'undefined' ? window.location.origin : ''

--- a/src/app/_parts/useHome.ts
+++ b/src/app/_parts/useHome.ts
@@ -46,7 +46,7 @@ export const useHome = () => {
           consensus: parseInt(consensus) || 0,
           diversity: parseInt(diversity) || 0,
           identityFusion: parseInt(identityFusion) || 0,
-          focus: parts[5] === 'focus',
+          focus: parts[5] === 'f',
         }
       })
 
@@ -77,7 +77,7 @@ export const useHome = () => {
         p.identityFusion,
       ]
       if (p.focus) {
-        parts.push('focus')
+        parts.push('f')
       }
       params.append('p', parts.join(','))
     })


### PR DESCRIPTION
- 「この結果のURLをコピー」ボタンからfocusが反映されたURLをクリップボードへコピーできない不具合を修正
- focusのフラグ名称を `f`に短縮