### PR TITLE
Add: pnpm minimumReleaseAge を設定しサプライチェーン対策 #105

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "current-gravity",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "stylelint-order": "^6.0.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.0"
+  },
+  "pnpm": {
+    "minimumReleaseAge": 10080
   }
 }


### PR DESCRIPTION
## Summary
- `package.json` に `pnpm.minimumReleaseAge: 10080`（7日 = 10080分）を追加し、リリース直後のパッケージインストールをブロック
- サプライチェーン攻撃対策（侵害された直後のパッケージ取り込みを防止）
- バージョンを 1.1.2 → 1.1.3 にマイクロバージョンアップ

Closes #105