### PR TITLE
Release: v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "current-gravity",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "stylelint-order": "^6.0.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.18.0"
+  },
+  "pnpm": {
+    "minimumReleaseAge": 10080
   }
 }


### PR DESCRIPTION
## v1.1.3

サプライチェーン対策として、pnpm でリリース直後のパッケージインストールをブロック。

### 内部的な変更

- `package.json` に `pnpm.minimumReleaseAge: 10080`（7日 = 10080分）を追加。リリース後7日未満のパッケージは `pnpm install` 時にブロックされ、侵害された直後のパッケージを取り込むリスクを低減。

Closes #105