### PR TITLE
Add: 設問回答にprogressを追加 #117

### DIFF
--- a/src/app/personal-plot/_parts/page.module.scss
+++ b/src/app/personal-plot/_parts/page.module.scss
@@ -56,6 +56,7 @@
   bottom: 0;
   z-index: 1;
   display: flex;
+  flex-wrap: wrap;
   place-content: center;
   justify-content: center;
   background-color: #f7f7f733;
@@ -71,11 +72,102 @@
   }
 
   @include mq(fromWide) {
-    gap: var(--spacing-lg);
+    gap: var(--spacing-xl);
+    align-items: center;
     padding: var(--spacing-lg) var(--spacing-lg);
   }
 }
 
+[class].submitButton,
+[class].backButton {
+  max-width: rem(320);
+}
+
+[class].backButton {
+  @include mq(narrow) {
+    order: 3;
+    width: 50%;
+  }
+
+  @include mq(fromWide) {
+    order: 1;
+  }
+}
+
 [class].submitButton {
-  max-width: rem(360);
+  @include mq(narrow) {
+    order: 2;
+    width: 50%;
+  }
+
+  @include mq(fromWide) {
+    order: 3;
+  }
+}
+
+.progress {
+  display: flex;
+  flex-direction: column;
+
+  @include mq(narrow) {
+    gap: var(--spacing-xs);
+    order: 1;
+    width: 100%;
+  }
+
+  @include mq(fromWide) {
+    gap: var(--spacing-sm);
+    order: 2;
+    width: rem(320);
+  }
+}
+
+.progressBar {
+  @include emboss;
+
+  height: var(--spacing-sm);
+  border-radius: rem(999);
+}
+
+.done {
+  position: relative;
+  height: 100%;
+  transition: width var(--transition-ease);
+
+  &::before,
+  &::after {
+    position: absolute;
+    inset: 0;
+    display: block;
+    content: '';
+    border-radius: rem(999);
+  }
+
+  &::before {
+    background-color: var(--bg-accent);
+    filter: blur(rem(1));
+    mix-blend-mode: multiply;
+  }
+
+  &::after {
+    background-color: var(--bg-accent);
+    filter: blur(rem(4));
+    mix-blend-mode: overlay;
+  }
+}
+
+.progressCount {
+  color: var(--txt-description);
+  text-align: center;
+  text-shadow:
+    rem(1) rem(1) rem(1) #fff,
+    rem(-1) rem(-1) rem(1) rgb(0 0 0 / 5%);
+
+  @include mq(narrow) {
+    font-size: var(--font-size-xs);
+  }
+
+  @include mq(fromWide) {
+    font-size: var(--font-size-sm);
+  }
 }

--- a/src/app/personal-plot/_parts/usePersonalPlot.ts
+++ b/src/app/personal-plot/_parts/usePersonalPlot.ts
@@ -35,6 +35,7 @@ export const usePersonalPlot = () => {
 
   const formRef = useRef<HTMLFormElement>(null)
   const [formValid, setFormValid] = useState(false)
+  const [answeredCount, setAnsweredCount] = useState(0)
 
   const [orderedQuestionList, setOrderedQuestionList] = useState<
     (typeof questionListData)[number][]
@@ -75,26 +76,27 @@ export const usePersonalPlot = () => {
     void router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
   }, [isMounted, parsedFromUrl, pathname, questionFromUrl, router, searchParams])
 
-  const syncFormValid = useCallback(() => {
+  const syncFormState = useCallback(() => {
     const el = formRef.current
     if (!el) return
     setFormValid(el.checkValidity())
+    setAnsweredCount(Object.keys(readAnswersFromForm(el)).length)
   }, [])
 
   useEffect(() => {
     if (!isMounted) return
-    syncFormValid()
-  }, [isMounted, syncFormValid])
+    syncFormState()
+  }, [isMounted, syncFormState])
 
-  /** URL からの事前選択直後など、20 問そろったあと submit 活性を合わせる */
+  /** URLからの事前選択直後など、20問そろったあとsubmit活性を合わせる */
   useEffect(() => {
     if (!isMounted || !isCompleteAnswersRecord(effectiveDefaults)) return
-    requestAnimationFrame(() => syncFormValid())
-  }, [effectiveDefaults, isMounted, syncFormValid])
+    requestAnimationFrame(() => syncFormState())
+  }, [effectiveDefaults, isMounted, syncFormState])
 
   const handleFormInput = useCallback(() => {
-    syncFormValid()
-  }, [syncFormValid])
+    syncFormState()
+  }, [syncFormState])
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -131,6 +133,7 @@ export const usePersonalPlot = () => {
     isMounted,
     formRef,
     formValid,
+    answeredCount,
     handleFormInput,
     effectiveDefaults,
     valueLocusQuestionList,

--- a/src/app/personal-plot/_parts/view.tsx
+++ b/src/app/personal-plot/_parts/view.tsx
@@ -16,6 +16,7 @@ export const PersonalPlotView: FC = () => {
     isMounted,
     formRef,
     formValid,
+    answeredCount,
     handleFormInput,
     effectiveDefaults,
     valueLocusQuestionList,
@@ -93,11 +94,22 @@ export const PersonalPlotView: FC = () => {
             variant="basic"
             size="full"
             type="button"
-            className={styles.submitButton}
+            className={styles.backButton}
             onClick={handleBack}
           >
             測定をやめて戻る
           </Button>
+          <div className={styles.progress}>
+            <p className={styles.progressCount}>
+              {answeredCount} / {totalCount}問
+            </p>
+            <div className={styles.progressBar}>
+              <div
+                className={styles.done}
+                style={{ width: `${totalCount ? (answeredCount / totalCount) * 100 : 0}%` }}
+              ></div>
+            </div>
+          </div>
           <Button
             variant="basic"
             size="full"

--- a/src/components/Question/Question.module.scss
+++ b/src/components/Question/Question.module.scss
@@ -10,7 +10,7 @@
   @include mq(narrow) {
     gap: var(--spacing-xl);
     padding: var(--spacing-xl) var(--spacing-lg);
-    scroll-margin-top: var(--spacing-xl);
+    scroll-margin-top: var(--spacing-sm);
   }
 
   @include mq(fromWide) {

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -12,7 +12,7 @@ import { useQuestion } from './useQuestion'
 
 import type { QuestionItem } from '@/type/question'
 
-import { STEP_LIST, AXIS_DESCRIPTION, POLE_LABEL, OPPOSITE_POLE } from '@/constants/model'
+import { STEP_LIST, AXIS_LABEL, POLE_LABEL, OPPOSITE_POLE } from '@/constants/model'
 
 type QuestionProps = {
   item: QuestionItem
@@ -45,8 +45,10 @@ export const Question: FC<QuestionProps> = ({
     <section id={`question-${index}`} className={styles.question}>
       <header className={styles.header}>
         <div className={styles.headerCategory}>
-          <p className={styles.headerLabel}>{AXIS_DESCRIPTION[axis]}</p>
-          <PoleLabel pole={pole} className={styles.headerPoleLabel} />
+          <p className={styles.headerLabel}>
+            {AXIS_LABEL[axis]}&nbsp;/&nbsp;
+            <PoleLabel pole={pole} className={styles.headerPoleLabel} />
+          </p>
         </div>
         <span className={styles.index}>Q{index + 1}</span>
         <h3 className={styles.title}>


### PR DESCRIPTION
設問回答にprogress（進捗バー）を追加。

## 変更内容

- 回答済み設問数を `answeredCount` state で保持し、進捗バー幅に反映
- 進捗バーが選択状態と同期しないバグ（`elements.length` 参照・演算子優先順位）を修正
- 設問ヘッダーのラベル表示とスクロール位置を調整

Closes #117
